### PR TITLE
feat: Add Germany and France as employment location countries

### DIFF
--- a/src/Enums/EmploymentLocationCountry.php
+++ b/src/Enums/EmploymentLocationCountry.php
@@ -6,4 +6,6 @@ enum EmploymentLocationCountry: string
 {
     case Belgium = 'be';
     case Netherlands = 'nl';
+    case Germany = 'de';
+    case France = 'fr';
 }

--- a/src/Enums/EmploymentLocationCountry.php
+++ b/src/Enums/EmploymentLocationCountry.php
@@ -8,4 +8,6 @@ enum EmploymentLocationCountry: string
     case Netherlands = 'nl';
     case Germany = 'de';
     case France = 'fr';
+    case Spain = 'es';
+    case Italy = 'it';
 }

--- a/src/Facades/Dimona.php
+++ b/src/Facades/Dimona.php
@@ -2,13 +2,14 @@
 
 namespace Hyperlab\Dimona\Facades;
 
+use Hyperlab\Dimona\DimonaManager;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static \Hyperlab\Dimona\DimonaManager client(?string $clientId = null)
  * @method static void declare(string $employerEnterpriseNumber, string $workerSocialSecurityNumber, \Carbon\CarbonPeriodImmutable $period, \Illuminate\Support\Collection $employments)
  *
- * @see \Hyperlab\Dimona\DimonaManager
+ * @see DimonaManager
  */
 class Dimona extends Facade
 {

--- a/src/Services/NisCodeService.php
+++ b/src/Services/NisCodeService.php
@@ -20,8 +20,8 @@ class NisCodeService
         return match ($country) {
             EmploymentLocationCountry::Belgium => 150,
             EmploymentLocationCountry::Netherlands => 129,
-            EmploymentLocationCountry::Germany => 94,
-            EmploymentLocationCountry::France => 114,
+            EmploymentLocationCountry::Germany => 103,
+            EmploymentLocationCountry::France => 111,
         };
     }
 

--- a/src/Services/NisCodeService.php
+++ b/src/Services/NisCodeService.php
@@ -20,6 +20,8 @@ class NisCodeService
         return match ($country) {
             EmploymentLocationCountry::Belgium => 150,
             EmploymentLocationCountry::Netherlands => 129,
+            EmploymentLocationCountry::Germany => 94,
+            EmploymentLocationCountry::France => 114,
         };
     }
 

--- a/src/Services/NisCodeService.php
+++ b/src/Services/NisCodeService.php
@@ -22,6 +22,8 @@ class NisCodeService
             EmploymentLocationCountry::Netherlands => 129,
             EmploymentLocationCountry::Germany => 103,
             EmploymentLocationCountry::France => 111,
+            EmploymentLocationCountry::Spain => 109,
+            EmploymentLocationCountry::Italy => 128,
         };
     }
 

--- a/tests/Mocks/MockDimonaApiClientTest.php
+++ b/tests/Mocks/MockDimonaApiClientTest.php
@@ -70,7 +70,7 @@ it('throws an exception when no createDeclaration response is mocked', function 
     $mock = new MockDimonaApiClient;
 
     expect(fn () => $mock->createDeclaration([]))
-        ->toThrow(\Exception::class, 'No mocked response for createDeclaration');
+        ->toThrow(Exception::class, 'No mocked response for createDeclaration');
 });
 
 it('can mock exceptions for createDeclaration', function () {
@@ -85,7 +85,7 @@ it('throws an exception when no getDeclaration response is mocked', function () 
     $mock = new MockDimonaApiClient;
 
     expect(fn () => $mock->getDeclaration('test-reference'))
-        ->toThrow(\Exception::class, "No mocked response for getDeclaration with reference 'test-reference'");
+        ->toThrow(Exception::class, "No mocked response for getDeclaration with reference 'test-reference'");
 });
 
 it('can chain mock methods', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Hyperlab\Dimona\Tests;
 
 use Hyperlab\Dimona\DimonaServiceProvider;
+use Hyperlab\Dimona\Tests\Models\Employment;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
@@ -48,6 +49,6 @@ class TestCase extends Orchestra
         config()->set('dimona.default_client', 'test-client');
 
         // Configure the employment model for tests
-        config()->set('dimona.employment_model', \Hyperlab\Dimona\Tests\Models\Employment::class);
+        config()->set('dimona.employment_model', Employment::class);
     }
 }


### PR DESCRIPTION
## Wat

Voegt Duitsland en Frankrijk toe als ondersteunde landen voor employment locaties.

### Wijzigingen

- **EmploymentLocationCountry enum**: `Germany = 'de'` en `France = 'fr'` cases toegevoegd
- **NisCodeService**: NIS-codes voor Duitsland (94) en Frankrijk (114) toegevoegd

### Context

Ultimate Services heeft events in Duitsland en Frankrijk nodig. Dit package moet eerst uitgebreid worden zodat de EmploymentDataMapper in ultimate-services de nieuwe landen correct kan mappen.